### PR TITLE
Remove 'compress' option from get_data endpoint

### DIFF
--- a/api/get_data.py
+++ b/api/get_data.py
@@ -15,18 +15,9 @@ def get_data(r_data):
         cursorclass=pymysql.cursors.DictCursor
     )
 
-
-    if "compressed" in r_data:
-        cursor = connection.cursor()
-        cursor.execute("SELECT MIN(number) as number, temperature, weight, humidity, DATE_FORMAT(`measured`, '%%Y-%%m-%%d %%H:%%i:%%S') as measured FROM `data` WHERE DATE(`measured`) BETWEEN '%s' AND '%s' GROUP BY CAST(`measured` as DATE)" % (r_data["from"], r_data["to"]))
-        result = cursor.fetchall()
-
-    else:
-        cursor = connection.cursor()
-        # cursor.execute("SELECT number, temperature, weight, humidity, DATE_FORMAT(`measured`, '%%Y-%%m-%%d %%H:%%i:%%S') as measured FROM `data` WHERE DATE(`measured`) BETWEEN '%s' AND '%s'" % (r_data["from"], r_data["to"]))
-        cursor.execute("SELECT * FROM `data` WHERE DATE(`measured`) BETWEEN '%s' AND '%s'" % (r_data["from"], r_data["to"]))
-
-        result = cursor.fetchall()
+    cursor = connection.cursor()
+    cursor.execute("SELECT * FROM `data` WHERE DATE(`measured`) BETWEEN '%s' AND '%s'" % (r_data["from"], r_data["to"]))
+    result = cursor.fetchall()
 
     fetched_data = {}
     row_count = 0

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -63,7 +63,7 @@ async function fetchData() {
                 from = dateTwo;
                 to = date;
                 view = "month";
-                response = await fetch("http://" + api_adress + "/api/data/get?from=" + dateTwo + "&to=" + date + "&compressed");
+                response = await fetch("http://" + api_adress + "/api/data/get?from=" + dateTwo + "&to=" + date);
                 break;
                 // Year
             case "4":
@@ -71,14 +71,14 @@ async function fetchData() {
                 from = year;
                 to = year;
                 view = year;
-                response = await fetch("http://" + api_adress + "/api/data/get?from=" + year + "-01-01&to=" + year + "-12-31&compressed");
+                response = await fetch("http://" + api_adress + "/api/data/get?from=" + year + "-01-01&to=" + year + "-12-31");
                 break;
                 // All
             case "5":
                 from = "2020";
                 to = "-";
                 view = "all";
-                response = await fetch("http://" + api_adress + "/api/data/get?from=2000-01-01&to=2099-12-31&compressed");
+                response = await fetch("http://" + api_adress + "/api/data/get?from=2000-01-01&to=2099-12-31");
                 break;
         }
     } else {

--- a/public/js/compare.js
+++ b/public/js/compare.js
@@ -38,7 +38,7 @@ async function fetchCompareData() {
                 from = dateTwo;
                 to = date;
                 view = "month";
-                response = await fetch("http://" + api_adress + "/api/data/get?from=" + dateTwo + "&to=" + date + "&compressed");
+                response = await fetch("http://" + api_adress + "/api/data/get?from=" + dateTwo + "&to=" + date);
                 break;
                 // Year
             case "4":
@@ -46,14 +46,14 @@ async function fetchCompareData() {
                 from = year;
                 to = year;
                 view = year;
-                response = await fetch("http://" + api_adress + "/api/data/get?from=" + year + "-01-01&to=" + year + "-12-31&compressed");
+                response = await fetch("http://" + api_adress + "/api/data/get?from=" + year + "-01-01&to=" + year + "-12-31");
                 break;
                 // All
             case "5":
                 from = "2020";
                 to = "-";
                 view = "all";
-                response = await fetch("http://" + api_adress + "/api/data/get?from=2000-01-01&to=2099-12-31&compressed");
+                response = await fetch("http://" + api_adress + "/api/data/get?from=2000-01-01&to=2099-12-31");
                 break;
         }
     } else {


### PR DESCRIPTION
Removed an option called 'compressed' from the _/api/data/get_ endpoint that was causing it to ... not work.