### PR TITLE
Fixed 'current data' cards layout on mobile view

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -206,7 +206,7 @@
             <h3 id="summary" style="margin-left: 20px;">Aktuell</h3>
 
             <div class="row">
-                <div class="beelogger-current-box col s4">
+                <div class="beelogger-current-box col s12 m4">
                     <div class="card blue-grey darken-1">
                         <div class="card-content white-text">
                             <span class="material-icons">thermostat</span>
@@ -216,7 +216,7 @@
                     </div>
                 </div>
 
-                <div class="beelogger-current-box col s4">
+                <div class="beelogger-current-box col s12 m4">
                     <div class="card blue-grey darken-1">
                         <div class="card-content white-text">
                             <span class="material-icons">monitor_weight</span>
@@ -226,7 +226,7 @@
                     </div>
                 </div>
 
-                <div class="beelogger-current-box col s4">
+                <div class="beelogger-current-box col s12 m4">
                     <div class="card blue-grey darken-1">
                         <div class="card-content white-text">
                             <span class="material-icons">water</span>


### PR DESCRIPTION
The layout of the 'current data' cards wasn't mobile responsive.

## Before: 
![Screenshot 2021-04-24 at 23 47 26](https://user-images.githubusercontent.com/36338179/115973773-db9a6a80-a557-11eb-896c-4f8dc9ef5511.png)

## Now:
![Screenshot 2021-04-24 at 23 47 59](https://user-images.githubusercontent.com/36338179/115973775-e05f1e80-a557-11eb-900d-a49056185e69.png)

