### PR TITLE
Changed view window for weight chart for better readability

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -155,8 +155,20 @@ async function drawWeightChart() {
     }
 
     var data_weight = google.visualization.arrayToDataTable(weightData);
-    var temp_chart = new google.visualization.LineChart(document.getElementById('weight_chart'));
-    temp_chart.draw(data_weight, detailChartOptions);
+    var weight_chart = new google.visualization.LineChart(document.getElementById('weight_chart'));
+    weight_chart.draw(data_weight, {
+        height: "100%",
+        width: "100%",
+        legend: {
+            position: 'bottom'
+        },
+        vAxis: {              
+            viewWindowMode:'explicit',
+            viewWindow:{
+                min: 15
+            }
+        }
+    });
 }
 
 async function drawHumidityChart() {


### PR DESCRIPTION
**Before, the weight chart was very hard to read and showed almost no development due to a too large view window:**
![Screenshot 2021-04-25 at 11 07 33](https://user-images.githubusercontent.com/36338179/115987693-7164e280-a5b6-11eb-8f85-5fe4523671e8.png)

**This PR should solve that issue:**
![Screenshot 2021-04-25 at 11 08 06](https://user-images.githubusercontent.com/36338179/115987714-85a8df80-a5b6-11eb-85d8-8fa059d57fc8.png)

_The data used above is just randomly generated test data._
