### PR TITLE
Fixed 'charts sometimes small' bug

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -17,12 +17,12 @@ document.addEventListener('DOMContentLoaded', () => {
     M.Dropdown.init(document.querySelectorAll('.dropdown-trigger'), {});
 
     // Fetching data and rendering charts with a little timeout
-    setTimeout(() => {
-        updateData();
-        drawCompareChart();
-        drawTempChart();
-        drawWeightChart();
-        drawHumidityChart();
+    setTimeout(async () => {
+        await updateData();
+        await drawCompareChart();
+        await drawTempChart();
+        await drawWeightChart();
+        await drawHumidityChart();
     }, 500);
 
     // Setting up background tasks for keeping the 'last updated' date up-to-date
@@ -182,7 +182,7 @@ async function drawWeightChart() {
         vAxis: {              
             viewWindowMode:'explicit',
             viewWindow:{
-                min: 15
+                min: 20
             }
         }
     });


### PR DESCRIPTION
Currently, there's a bug where the chart will sometimes render with a too small width (instead of 100%).
This PR (hopefully) fixes this issue by executing the chart rendering functions using async await.
![Screenshot 2021-04-26 at 17 38 27](https://user-images.githubusercontent.com/36338179/116112866-45ca2100-a6b8-11eb-806e-ff03e2b8a63f.png)
