### PR TITLE
Implement date range for all charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,5 @@ Note that this plugin makes the browser otherwise unusable since it forces to on
 # Third party dependencies
 ## Front-End
 * [Materialize](https://materializecss.com/)
-* [jQuery](https://jquery.com/)
 * [Material Icons](https://fonts.google.com/icons)
 * [Google Charts](https://developers.google.com/chart)

--- a/generate_test_data.py
+++ b/generate_test_data.py
@@ -27,7 +27,7 @@ while month != 13:
                 if len(str(hour)) == 1: hhour = "0" + str(hour)
                 final_date = "2021-" + str(mmonth) + "-" + str(dday) + " " + str(hhour) + ":13:06"
                 final_date = datetime.datetime.strptime(final_date, "%Y-%m-%d %H:%M:%S")
-                cursor.execute("INSERT INTO `data` (`number`, `temperature`, `weight`, `humidity`, `measured`) VALUES (0, %s, %s, %s, '%s')" % (round(random.uniform(20.0, 30.0), 2), round(random.uniform(50.0, 70.0), 2), round(random.uniform(90.0, 120.0), 2), final_date))
+                cursor.execute("INSERT INTO `data` (`number`, `temperature`, `weight`, `humidity`, `measured`) VALUES (0, %s, %s, %s, '%s')" % (round(random.uniform(20.0, 30.0), 2), round(random.uniform(20.0, 30.0), 2), round(random.uniform(40.0, 90.0), 2), final_date))
                 connection.commit()
                 print("Generated data for ", final_date, ".")
                 hour += 1

--- a/pages/components/modals.html
+++ b/pages/components/modals.html
@@ -97,16 +97,16 @@
     <div class="modal-content">
         <div class="input-field">
             <h4>Zeitraum ändern <span class="badge red white-text">Experimentelle Funktion</span></h4>
-            <select id="dropSelect">
+            <p>Dieses Feature ist experimentell und temporär deaktiviert, da es sich in der Überarbeitung befindet.</p>
+            <select id="dropSelect" disabled>
                 <option value="1">Heute</option>
                 <option value="2">Eine Woche</option>
                 <option value="3">Ein Monat</option>
                 <option value="4">Ein Jahr</option>
-                <option value="5">Gesamt</option>
             </select>
             <div class="container center">
-                <button onclick="drawCompareChart()" class="waves-effect waves-light btn"
-                    style="margin-left: 10px; margin-bottom: 3%;">Ansicht ändern</button>
+                <button onclick="updateCharts();" class="waves-effect waves-light btn"
+                    style="margin-left: 10px; margin-bottom: 3%;" disabled>Ansicht ändern</button>
             </div>
         </div>
     </div>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -8,6 +8,7 @@
 
 // Global variables
 var last_measured;
+var response;
 
 document.addEventListener('DOMContentLoaded', () => {
     // Initializing used Materialize components
@@ -18,11 +19,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Fetching data and rendering charts with a little timeout
     setTimeout(async () => {
-        await updateData();
-        await drawCompareChart();
-        await drawTempChart();
-        await drawWeightChart();
-        await drawHumidityChart();
+        response = await fetchData();
+        await updateCharts();
     }, 500);
 
     // Setting up background tasks for keeping the 'last updated' date up-to-date
@@ -58,7 +56,7 @@ async function fetchData() {
             // Month
             case '3':
                 var dateTwo = luxon.DateTime.now().minus({ months: 1 }).toISODate();
-                response = await fetch('/api/data/get?from=' + date + '&to=' + date);
+                response = await fetch('/api/data/get?from=' + dateTwo + '&to=' + date);
                 break;
 
             // Year
@@ -76,7 +74,7 @@ async function fetchData() {
 
 // Function for updating the 'current data' section
 async function updateData() {
-    let response = await fetchData();
+    response = await fetchData();
 
     if(Object.keys(response).length <= 0) {
         let card = '<div class="row"><div class="col m3"></div><div class="col m5"><div class="card blue-grey darken-1"><div class="card-image"><img src="../assets/bee.png"><span class="card-title">Keine Daten erhalten!</span></div><div class="card-content white-text"><p>Der Server hat für den ausgewählten Zeitraum keine Daten zurückgegeben. Diese wurden aufgrund eines temporären technischen Fehlers entweder nicht gemessen oder es gibt Verbindungsprobleme mit der Datenbank.</p></div></div></div><div class="col m3"></div></div>';
@@ -104,15 +102,26 @@ async function getStatistics() {
     document.querySelector('#website-count').innerHTML = res['website'];
 }
 
+async function updateCharts() {
+    await updateData();
+    await drawCharts();
+}
+
+async function drawCharts() {
+    await drawCompareChart();
+    await drawTempChart();
+    await drawWeightChart();
+    await drawHumidityChart();
+}
+
 async function drawCompareChart() {
-    var c = await fetchData();
     var compareData = [
         ['Tag', 'Temperatur (°C)', 'Gewicht (KG)', 'Luftfeuchtigkeit (%)']
     ];
 
-    for (row in c) {
-        var measured = new Date(c[row].measured);
-        compareData.push([measured, c[row].temperature, c[row].weight, c[row].humidity]);
+    for (row in response) {
+        var measured = new Date(response[row].measured);
+        compareData.push([measured, response[row].temperature, response[row].weight, response[row].humidity]);
     }
 
     var from = luxon.DateTime.fromJSDate(compareData[1][0]).toISODate();
@@ -142,7 +151,6 @@ async function drawCompareChart() {
 
 async function drawTempChart() {
     var tempData = [['Gemessen', 'Temperatur (°C)']];
-    let response = await fetchData();
 
     for (row in response) {
         var measured = new Date(response[row].measured);
@@ -165,7 +173,6 @@ async function drawTempChart() {
 
 async function drawWeightChart() {
     var weightData = [['Gemessen', 'Gewicht (kg)']];
-    let response = await fetchData();
 
     for (row in response) {
         var measured = new Date(response[row].measured);
@@ -185,7 +192,6 @@ async function drawWeightChart() {
 
 async function drawHumidityChart() {
     var humidityData = [['Gemessen', 'Luftfeuchtigkeit (%)']];
-    let response = await fetchData();
 
     for (row in response) {
         var measured = new Date(response[row].measured);


### PR DESCRIPTION
The menu for changing the date range was only able to change the date range for the compare chart.

This PR brings implementation of this feature for all charts.

At the same time, **the date range feature has been temporarily disabled on the front-end**.

**Why is that?**
This feature itself works on the front-end now, it requires a modification of the back-end though, due to too many data sets being returned from the API for each day (especially for month or year view).

**Why should this be already merged then?**
Before the implementation of this feature, each chart's (draw) function requested the data from the API (separately). This PR implements global storage of the API data, which reduces the number of API calls to the same route from 4 to 1 (per page [re]load). Also, I added a note to the modal so that users aren't confused anymore why this feature doesn't work.