### PR TITLE
Fixed updates of last PR

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -33,11 +33,11 @@
     <div class="row center" id="loading">
         <div class="card col s10 m6 offset-s1 offset-m3 blue-grey darken-1" style="margin-top: 40px;">
             <div class="card-content white-text">
-                <span class="card-title">Daten werden geladen...</span>
-                <div class="progress">
+                <span id="loading-title" class="card-title">Daten werden geladen...</span>
+                <div id="loading-progress" class="progress">
                     <div class="indeterminate"></div>
                 </div>
-                <p>Die Daten werden aus unserer Datenbank abgerufen. Dies kann einen Moment dauern.</p>
+                <p id="loading-text">Die Daten werden aus unserer Datenbank abgerufen. Dies kann einen Moment dauern.</p>
             </div>
         </div>
     </div>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -10,30 +10,35 @@
 var last_measured;
 var response;
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
     // Initializing used Materialize components
     M.Sidenav.init(document.querySelectorAll('.sidenav'), {});
     M.Modal.init(document.querySelectorAll('.modal'), {});
     M.FormSelect.init(document.querySelectorAll('select'), {});
     M.Dropdown.init(document.querySelectorAll('.dropdown-trigger'), {});
 
-    // Fetching data and rendering charts with a little timeout
-    setTimeout(async () => {
-        await updateCharts();
-        window.onresize = async () => {
-            await drawCharts();
-        };
-    }, 500);
+    response = await fetchData();
 
-    // Setting up background tasks for keeping the 'last updated' date up-to-date
+    // Setting up background task for keeping the 'measured' date up-to-date
     setInterval(() => {
         var measured = luxon.DateTime.fromISO(last_measured).toRelative({ locale: 'de' });
         document.querySelector('#updated').innerHTML = measured;
     }, 15000);
-});
 
-google.charts.load('current', {
-    'packages': ['corechart']
+    // Initializing google charts
+    await google.charts.load('current', {
+        'packages': ['corechart'],
+        // Callback to just draw charts and show data if charts lib is loaded
+        'callback': async () => {
+            await updateData();
+            await drawCharts();
+            // Event handler for automatically resizing charts on screen resize
+            window.onresize = async () => {
+                await drawCharts();
+            };
+        }
+    });
+
 });
 
 // ISO date format => 2021-04-25
@@ -41,35 +46,53 @@ var date = luxon.DateTime.now().toISODate();
 
 async function fetchData() {
     var compareValue = document.getElementById('dropSelect');
-
+    var url;
+    
+    // Handling date range dropdown and just fetching data for the corresponding time frame
     if (compareValue) {
         switch (compareValue.options[compareValue.selectedIndex].value) {
             // Today
             case '1':
-                response = await fetch('/api/data/get?from=' + date + '&to=' + date);
+                url = '/api/data/get?from=' + date + '&to=' + date;
                 break;
             
             // Week
             case '2':
                 var dateTwo = luxon.DateTime.now().minus({ weeks: 1 }).toISODate();
-                response = await fetch('/api/data/get?from=' + dateTwo + '&to=' + date);
+                url = '/api/data/get?from=' + dateTwo + '&to=' + date;
                 break;
             
             // Month
             case '3':
                 var dateTwo = luxon.DateTime.now().minus({ months: 1 }).toISODate();
-                response = await fetch('/api/data/get?from=' + dateTwo + '&to=' + date);
+                url = '/api/data/get?from=' + dateTwo + '&to=' + date
                 break;
 
             // Year
             case '4':
                 var dateTwo = luxon.DateTime.now().minus({ years: 1 }).toISODate();
-                response = await fetch('/api/data/get?from=' + dateTwo + '&to=' + date);
+                url = '/api/data/get?from=' + dateTwo + '&to=' + date;
                 break;
         }
+
+        response = await fetch(url);
     
     // If no view is selected, fetch current data
     } else response = await fetch('/api/data/get?from=' + date + '&to=' + date);
+
+    // Checking if valid data is returned and not some error
+    if(!response.ok) {
+        document.getElementById('loading-title').innerHTML = '❌ Momentan nicht verfügbar';
+        document.getElementById('loading-text').innerHTML = `
+            <hr>
+            <b>Das Laden der Daten ist fehlgeschlagen!</b><br>
+            Dies kann daran liegen, dass unsere Datenschnittstelle gerade offline ist,
+            wir Wartungen vornehmen oder aufgrund eines Vorfalls keine aktuellen Daten
+            aufgezeichnet wurden.<hr>
+            <b>Schaue einfach später nochmal vorbei</b>, wir haben das sicher bald repariert!
+        `;
+        document.getElementById('loading-progress').classList.remove('progress');
+    }
 
     return await response.json();
 }
@@ -77,13 +100,7 @@ async function fetchData() {
 // Function for updating the 'current data' section
 async function updateData() {
     response = await fetchData();
-
-    if(Object.keys(response).length <= 0) {
-        let card = '<div class="row"><div class="col m3"></div><div class="col m5"><div class="card blue-grey darken-1"><div class="card-image"><img src="../assets/bee.png"><span class="card-title">Keine Daten erhalten!</span></div><div class="card-content white-text"><p>Der Server hat für den ausgewählten Zeitraum keine Daten zurückgegeben. Diese wurden aufgrund eines temporären technischen Fehlers entweder nicht gemessen oder es gibt Verbindungsprobleme mit der Datenbank.</p></div></div></div><div class="col m3"></div></div>';
-        document.querySelector('#loading').innerHTML = card;
-        return
-    }
-
+    
     last_measured = response[Object.keys(response).length - 1].measured;
     var measured = luxon.DateTime.fromISO(last_measured).toRelative({ locale: 'de' });
 
@@ -102,11 +119,6 @@ async function getStatistics() {
     document.querySelector('#inserted-count').innerHTML = res['insert_calls'];
     document.querySelector('#requested-count').innerHTML = res['data_calls'];
     document.querySelector('#website-count').innerHTML = res['website'];
-}
-
-async function updateCharts() {
-    await updateData();
-    await drawCharts();
 }
 
 async function drawCharts() {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -19,7 +19,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Fetching data and rendering charts with a little timeout
     setTimeout(async () => {
-        response = await fetchData();
         await updateCharts();
         window.onresize = async () => {
             await drawCharts();


### PR DESCRIPTION
Finally figured out what the problem was.

The function that draws all the charts was in a setTimeout function. This was to make sure the charts library was properly initialized. The problem is that the library sometimes (every now and then) needs longer than you'd expect to properly load up! This is why now, instead of a setTimeout function, it uses a callback function from the load function of the library, so that nothing can go wrong there!

I added one other thing as well:
![Screenshot 2021-04-27 at 19 34 56](https://user-images.githubusercontent.com/36338179/116286571-a7a98a00-a78f-11eb-8a01-866ba1af9f2d.png)

Now there's a quick check of the HTTP status returned from fetch. If something goes wrong now, there's a nice little error message instead of the infinite progress bar.
