### PR TITLE
Modular system for embedded pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -48,7 +48,7 @@ print("################################")
 @app.route("/")
 def mainPage():
     statistics.update("website")
-    return render_template("index.html")
+    return render_template("index.html", sidenav_links=config.embedded_pages)
 
 @app.route("/display")
 def display():
@@ -58,10 +58,19 @@ def display():
         return redirect("/")
         
     return render_template("display.html")
-    
-@app.route("/gallery")
-def gallery():
-    return render_template("gallery.html")
+
+@app.route("/<page>")
+def embeddedPage(page):
+    pages = config.embedded_pages
+
+    if not page in pages.keys():
+        return "this page doesn't exist"
+
+    return render_template("embed.html", page=pages[page])
+
+# @app.route("/gallery")
+# def gallery():
+#     return render_template("gallery.html")
 
 # Shouldn't be active in production (since anyone could insert data)
 # @app.route("/simulate")

--- a/app.py
+++ b/app.py
@@ -68,15 +68,6 @@ def embeddedPage(page):
 
     return render_template("embed.html", page=pages[page])
 
-# @app.route("/gallery")
-# def gallery():
-#     return render_template("gallery.html")
-
-# Shouldn't be active in production (since anyone could insert data)
-# @app.route("/simulate")
-# def simulate():
-#     return render_template("simulate.html")
-
 @app.route("/post_contact", methods=["POST"])
 def contactPost():
     message = request.form["message"]

--- a/example_config.py
+++ b/example_config.py
@@ -32,3 +32,8 @@ class Mail:
     port = 587
     user = ""
     password = ""
+
+# Pages that are 'mounted' at /<key> and embedded using an iframe
+embedded_pages = {
+    # "examplePage": "https://example.org"
+}

--- a/pages/components/sidenav.html
+++ b/pages/components/sidenav.html
@@ -16,7 +16,9 @@
 
     <li><div class="divider"></div></li>
     <li><a class="subheader">Externe Seiten</a></li>
-    <li><a class="waves-effect" href="/gallery"><i class="material-icons-outlined">collections</i>Galerie</a></li>
+    {% for link in links.keys() %}
+        <li><a class="waves-effect" href="/{{ link }}"><i class="material-icons-outlined">link</i>{{ link }}</a></li>
+    {% endfor %}
 
     <li><div class="divider"></div></li>
     <br>

--- a/pages/embed.html
+++ b/pages/embed.html
@@ -29,6 +29,6 @@
         </div>
     </nav>
 
-    <iframe src="https://beelogger.itechnious.com:6677" frameborder="0" width="100%" height="100%"></iframe>
+    <iframe src="{{ page }}" sandbox="allow-scripts allow-forms allow-modals allow-same-origin allow-popups allow-popups-to-escape-sandbox" frameborder="0" width="100%" height="100%"></iframe>
 </body>
 </html>

--- a/pages/index.html
+++ b/pages/index.html
@@ -52,7 +52,9 @@
         <a class="weatherwidget-io" href="https://forecast7.com/de/53d247d47/leer/" data-label_1="LEER"
             data-label_2="WETTER" data-theme="original">LEER WETTER</a>
 
-        {% include './components/sidenav.html' %}
+        {% with links=sidenav_links %}
+            {% include './components/sidenav.html' %}
+        {% endwith %}
 
         {% include './components/modals.html' %}
 


### PR DESCRIPTION
External pages can now easily be mounted into the sidebar and a custom URL (which will hold the page embedded in an iframe, as well as a 'BeeLogger' branded header) by appending a name and a link to it to the embedded_pages dictionary in the config file.

Example configuration:
![Screenshot 2021-06-04 at 20 49 03](https://user-images.githubusercontent.com/36338179/120849373-4e92fa00-c576-11eb-81b5-55b9791d54f6.png)

The sidebar:
![Screenshot 2021-06-04 at 20 49 37](https://user-images.githubusercontent.com/36338179/120849496-76825d80-c576-11eb-8e8c-51d094427313.png)

The embedded page:
![Screenshot 2021-06-04 at 20 50 40](https://user-images.githubusercontent.com/36338179/120849535-88640080-c576-11eb-9676-aed36ef70e7a.png)
