### PR TITLE
Back-End: Add MySQL Auto-Init (#59)

### DIFF
--- a/api/insert_data.py
+++ b/api/insert_data.py
@@ -1,7 +1,6 @@
 from flask.globals import request
 from database import Database
 from flask import request
-import pymysql
 import config
 
 

--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ import os
 from blueprints.api import api
 from blueprints.views import views
 from flask import Flask
+from database import Database
 from jsonencoder import CustomJSONEncoder
 
 # from crossdomain import crossdomain
@@ -18,6 +19,18 @@ print("#    -----------------------   #")
 print("#    by Fabian R., Soenke K.   #")
 print("################################")
 
+print("\nInitializing database...")
+
+database = Database()
+
+try:
+    database.prepare_database()
+    print("Database prepared.")
+except Exception as exception:
+    print("An error occurred while trying to connect to (and prepare) the database:")
+    raise exception
+
+# Initialize Flask app
 app = Flask("BeeLogger", static_folder='public', static_url_path='', template_folder='pages')
 app.config['TEMPLATES_AUTO_RELOAD'] = True
 app.json_encoder = CustomJSONEncoder

--- a/database.py
+++ b/database.py
@@ -13,6 +13,43 @@ class Database:
             "charset": "utf8mb4",
             "cursorclass": pymysql.cursors.DictCursor
         }
+    
+    def get_sql_from_file(self):
+        """
+        Reads and parses SQL queries from provided .sql file.
+        """
+        from os import path
+
+        file = "database.sql"
+
+        # File did not exists
+        if path.isfile(file) is False:
+            print("Unable to open sql file '{}'.".format(file))
+            return False
+        else:
+            with open(file, "r") as sql_file:
+                query = sql_file.read().split(';')
+                query.pop()
+                return query
+
+    def prepare_database(self) -> None:
+        """
+        Utilizes SQL from 'database.sql' to create all needed
+        tables automatically.
+        """
+        connection = pymysql.connect(**self.mysql_args)
+        cursor = connection.cursor()
+        
+        # SQL queries as a list
+        queries = self.get_sql_from_file()
+        for query in queries:
+            cursor.execute(query)
+
+        # Commit changes and close connection
+        connection.commit()
+        connection.close()
+        return
+        
 
     def get_data(self, from_date, to_date):
         connection = pymysql.connect(**self.mysql_args)

--- a/database.sql
+++ b/database.sql
@@ -19,10 +19,9 @@
 -- Table structure for table `data`
 --
 
-DROP TABLE IF EXISTS `data`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `data` (
+CREATE TABLE IF NOT EXISTS `data` (
   `number` bigint(20) NOT NULL AUTO_INCREMENT,
   `temperature` double DEFAULT NULL,
   `weight` double DEFAULT NULL,


### PR DESCRIPTION
Fix #59 by adding a `get_sql_from_file()` function to the database
object to read and parse the provided 'database.sql' file and a
`prepare_database()` function to execute the queries (therefore, all
needed MySQL tables will be created automatically).