### PR TITLE
Feeds: Add Simple Back Buttons

### DIFF
--- a/pages/feed-article.html
+++ b/pages/feed-article.html
@@ -5,7 +5,7 @@
 {% block content %}
 <main>
     <div class="container">
-        <a class="btn" style="margin-top: 30px;" href="/rss/{{ feed_name }}/?pretty">Zurück zum Feed</a>
+        <a class="btn" style="margin-top: 30px;" onclick="history.back();">Zurück zum Feed</a>
         <h1>{{ article["title"] }}</h1>
         <h5>{{ article["time"] }}</h5>
         <p style="font-size: 120%;">{{ article["text"] }}</p>

--- a/pages/feed.html
+++ b/pages/feed.html
@@ -8,6 +8,8 @@
         <div class="container">
             <h1>{{ feed_name.upper() }} Feed</h1>
 
+            <a class="btn" style="margin-top: 30px;" onclick="history.back();">Zurück zur Übersicht</a>
+
             <div class="card blue-grey darken-1 center-align white-text" style="padding: 20px;">
                 <h5>QR Code zum {{ feed_name.upper() }} RSS Feed:</h5>
                 <img id="rss-qr-code" src="" alt="Unable to generate RSS QR code.">

--- a/pages/feeds.html
+++ b/pages/feeds.html
@@ -8,6 +8,8 @@
         <div class="container">
             <h1>BeeLogger Feeds</h1>
 
+            <a class="btn" style="margin-top: 30px;" onclick="history.back();">Zurück</a>
+
             <p style="font-size: 120%;">
                 BeeLogger verfügt über sogenannte Feeds, in denen automatisierte
                 System-Benachrichtigungen zu finden sind.


### PR DESCRIPTION
Add simple "Back" buttons to the UI using JavaScript's `history.back();`
method.

Currently, the buttons are also shown in the display iframe. However, we can still merge this as I think there should be a new implementation of feeds on the display using a separate tab anyway.

Fix #84 